### PR TITLE
Ensure stack 8 byte aligned at start of gt_context_trampoline

### DIFF
--- a/gt.c
+++ b/gt.c
@@ -46,7 +46,7 @@
 
         sp = (gt_GenReg *) ((uintptr_t) ucp->stack.stackptr + ucp->stack.size);
         sp -= link;
-        sp = (gt_GenReg *) (((uintptr_t) sp & -16L) - 8);
+        sp = (gt_GenReg *) (((uintptr_t) sp & -16L));
 
         ucp->mach_context.gen_regs[GT_REG_RIP] = (uintptr_t) func;
         ucp->mach_context.gen_regs[GT_REG_RBX] = (uintptr_t) &sp[link];


### PR DESCRIPTION
I don't think you are ensuring proper stack alignment when` gt_context_trampoline` is called: 

```
Breakpoint 1, gt_context_trampoline () at ./gt.c:27
27    {
(gdb) bt
#0  gt_context_trampoline () at ./gt.c:27
#1  0x00005555555a80a0 in ?? ()
#2  0x0000000000000000 in ?? ()
(gdb) info sp
Undefined info command: "sp".  Try "help info".
(gdb) info reg
...
rsp            0x7ffff7fbeff0      0x7ffff7fbeff0
```

As per the PCS, the stack needs to be 16-byte aligned at the time of a call instruction which means 8-byte alignment upon function entry.